### PR TITLE
refactor : #22 - 사용자의 해당 오더 주문목록을 가져오는 기준변경

### DIFF
--- a/src/main/java/com/proceed/swhackathon/repository/OrderDetailRepository.java
+++ b/src/main/java/com/proceed/swhackathon/repository/OrderDetailRepository.java
@@ -15,7 +15,7 @@ public interface OrderDetailRepository extends JpaRepository<OrderDetail, Long> 
     @Query("select od from OrderDetail od where od.menu.store = :store")
     List<OrderDetail> findByStore(Store store);
 
-    @Query("select od from OrderDetail od where od.user = :user and od.order = :order")
+    @Query("select od from OrderDetail od where od.user = :user and od.order = :order and od.menuCheck = true")
     List<OrderDetail> findByUserAndOrder(User user, Order order);
 
     @Query("select od from OrderDetail od where od.menu = :menu")
@@ -27,7 +27,7 @@ public interface OrderDetailRepository extends JpaRepository<OrderDetail, Long> 
     @Query("select od from OrderDetail od join fetch od.menu m where od.user = :user and od.order = :order and  m = :menu and od.menuCheck = true")
     Optional<OrderDetail> findByUserAndOrderAndMenuV2(User user, Order order, Menu menu);
 
-    @Query("select od from OrderDetail od join fetch od.userOrderDetail uod where uod = :uod and od.menuCheck = true and od.user = :user")
+    @Query("select od from OrderDetail od join fetch od.userOrderDetail uod where uod = :uod and od.user = :user")
     List<OrderDetail> selectUOD(UserOrderDetail uod, User user);
 
     @Query("select od from OrderDetail od join fetch od.order odo where od.menuCheck = true and odo <> :order and od.user = :user")

--- a/src/main/java/com/proceed/swhackathon/service/OrderDetailService.java
+++ b/src/main/java/com/proceed/swhackathon/service/OrderDetailService.java
@@ -170,7 +170,6 @@ public class OrderDetailService {
         List<OrderDetail> ods = orderDetailRepository.findByUserAndOrder(user, order);
         for (OrderDetail od : ods) {
             od.setUserOrderDetail(uod);
-            od.setMenuCheck(false); // 주문 완료된 장바구니 요소들은 모두 menuCheck를 해제해준다.
         }
 
         uod.setOrderDetails(ods);
@@ -178,6 +177,11 @@ public class OrderDetailService {
 
         // 최근 주문 오더 수정
         order.getStore().setRecentlyOrder(order);
+
+        // 주문 완료된 장바구니 요소들은 모두 menuCheck를 해제해준다.
+        for (OrderDetail od : ods){
+            od.setMenuCheck(false);
+        }
 
 
         return UserOrderDetailDTO.entityToDTO(uod);
@@ -196,7 +200,7 @@ public class OrderDetailService {
         });
 
         List<OrderDetail> ods = orderDetailRepository.selectUOD(uod, user);
-        ods.removeIf(od -> !od.isMenuCheck());
+//        ods.removeIf(od -> !od.isMenuCheck());
         uod.setOrderDetails(ods);
 
         return UserOrderDetailDTO.entityToDTO(uod);


### PR DESCRIPTION
기존 menuCheck가 True여야 했는데 menuCheck는 현재 장바구니에 들어있는지 들어있지 않는지 체크하는 용도로 변환되었기 때문에 menuCheck를 판단할 필요가 없다고여겨 변경